### PR TITLE
Add travis support for CI (not CD)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,13 @@ language: java
 jdk:
   - openjdk11
 
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install ant-optional
+
 before_script:
   - cd build
 
 script:
   - ant clean
-  - ant build -lib ../core/library-test/junit-4.8.1.jar -lib ../core/library-test/mockito-all-1.10.19.jar
+  - ant build

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ before_script:
 
 script:
   - ant clean
-  - ant build
+  - ant build -lib ../core/library-test/junit-4.8.1.jar -lib ../core/library-test/mockito-all-1.10.19.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+git:
+  depth: 1
+
+language: java
+
+jdk:
+  - openjdk11
+
+before_script:
+  - cd build
+
+script:
+  - ant clean
+  - ant build


### PR DESCRIPTION
Based off of processing 5753, demonstrates the use of Travis to build and test processing Requires use of OpenJDK (processing 5753). Will address processing 2747. Will redirect this to the original processing repo after processing 5753 is resolved.

Note that this supersedes sampottinger/processing's #7 and #70 - this does not include the deploy step.