### PR TITLE
Minor fix in PreprocessorResult dimension reporting.

### DIFF
--- a/java/src/processing/mode/java/preproc/PreprocessorResult.java
+++ b/java/src/processing/mode/java/preproc/PreprocessorResult.java
@@ -193,6 +193,6 @@ public class PreprocessorResult {
    *    given.
    */
   public String getSketchHeight() {
-    return sketchWidth;
+    return sketchHeight;
   }
 }


### PR DESCRIPTION
Fix issue reported by @codeanticode within PreprocessorResult.java where the height was not being returned correctly.