### PR TITLE
[Fork] Migrate to JNA 5 compatiable Native.load.

### DIFF
--- a/app/src/processing/app/platform/DefaultPlatform.java
+++ b/app/src/processing/app/platform/DefaultPlatform.java
@@ -129,7 +129,7 @@ public class DefaultPlatform {
 
 
   public interface CLibrary extends Library {
-    CLibrary INSTANCE = Native.loadLibrary("c", CLibrary.class);
+    CLibrary INSTANCE = Native.load("c", CLibrary.class);
     int setenv(String name, String value, int overwrite);
     String getenv(String name);
     int unsetenv(String name);

--- a/app/src/processing/app/platform/WindowsPlatform.java
+++ b/app/src/processing/app/platform/WindowsPlatform.java
@@ -560,7 +560,7 @@ public class WindowsPlatform extends DefaultPlatform {
   static WinLibC getLibC() {
     if (clib == null) {
       try {
-        clib = Native.loadLibrary("msvcrt", WinLibC.class);
+        clib = Native.load("msvcrt", WinLibC.class);
       } catch (UnsatisfiedLinkError ule) {
         Messages.showTrace("JNA Error",
                            "JNA could not be loaded. Please report here:\n" +


### PR DESCRIPTION
Related to https://github.com/processing/processing4/issues/7, move from loadLibrary to interface compatible load per https://github.com/java-native-access/jna/blob/master/www/GettingStarted.md  (see https://github.com/java-native-access/jna/commit/00d6b1387c198a785e05c0a94dc7cdb4e4df0bb1).