### PR TITLE
[Fork] Fix font size calculation issue in the editor console.

### DIFF
--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -79,7 +79,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
   protected EditorState state;
   protected Mode mode;
 
-  static public final int LEFT_GUTTER = Toolkit.zoom(44);
+  static public final int LEFT_GUTTER = Toolkit.zoom(45);
   static public final int RIGHT_GUTTER = Toolkit.zoom(12);
   static public final int GUTTER_MARGIN = Toolkit.zoom(3);
 

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -79,7 +79,10 @@ public abstract class Editor extends JFrame implements RunnerListener {
   protected EditorState state;
   protected Mode mode;
 
+  // There may be certain gutter sizes which cause text bounds inside the console to be calculated incorrectly. 45
+  // seems to work but change with caution.
   static public final int LEFT_GUTTER = Toolkit.zoom(45);
+
   static public final int RIGHT_GUTTER = Toolkit.zoom(12);
   static public final int GUTTER_MARGIN = Toolkit.zoom(3);
 


### PR DESCRIPTION
Responding to https://github.com/processing/processing4/issues/19, there appears to be an issue with calculating the bounds of text inside JTextPane within EditorConsole for specific font family and size combinations. This may be related to https://bugs.openjdk.java.net/browse/JDK-8158370 or https://bugs.openjdk.java.net/browse/JDK-8156217 but resolves when changing Editor.LEFT_GUTTER from 44 to basically anything else.