### PR TITLE
[fork] Ant test refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,4 @@ before_script:
 script:
   - ant clean
   - ant build
+  - ant test

--- a/build/build.xml
+++ b/build/build.xml
@@ -354,7 +354,7 @@
 
   <target name="downloader-setup">
     <!-- make sure we're built -->
-    <subant buildpath="jre" target="dist" />
+    <subant buildpath="jre" target="dist-no-test" />
 
     <!-- define our special JRE downloader task -->
     <taskdef name="downloader"
@@ -482,7 +482,7 @@
     <antcall target="${target-platform}-run-app" />
   </target>
 
-  <target name="dist" depends="revision-check"
+  <target name="dist" depends="revision-check, test"
           description="Build Processing for distribution.">
     <input message="Enter version number:"
            addproperty="version"
@@ -524,6 +524,12 @@
 
     <!-- make sure this isn't around from an old build 140730 -->
     <delete dir="../java/examples" />
+  </target>
+
+  <target name="test" depends="build">
+    <subant buildpath="../core" target="test"/>
+    <subant buildpath="../java" target="test"/>
+    <subant buildpath="jre" target="test" />
   </target>
 
   <target name="subprojects-build">

--- a/build/jre/build.xml
+++ b/build/jre/build.xml
@@ -47,13 +47,15 @@
     </junit>
   </target>
 
-  <target name="compile" depends="test">
+  <target name="compile">
     <compilecommon srcdir="src" destdir="bin" classpath="classpath.base" />
   </target>
 
-  <target name="dist" depends="compile">
+  <target name="dist-no-test" depends="compile">
     <jar basedir="bin" destfile="downloader.jar" />
   </target>
+
+  <target name="dist" depends="test, dist-no-test" />
 
   <target name="demo" depends="dist">
     <taskdef name="downloader"

--- a/core/build.xml
+++ b/core/build.xml
@@ -96,7 +96,7 @@
     <delete dir="resource-test/scratch" />
   </target>
 
-  <target name="test" depends="build, test-compile, clean-pre-test">
+  <target name="test" depends="methods-build, build, test-compile, clean-pre-test">
     <junit haltonfailure="true">
       <classpath refid="classpath.test" />
       <formatter type="brief" usefile="false" />

--- a/core/build.xml
+++ b/core/build.xml
@@ -96,7 +96,7 @@
     <delete dir="resource-test/scratch" />
   </target>
 
-  <target name="test" depends="methods-build, build, test-compile, clean-pre-test">
+  <target name="test" depends="build, test-compile, clean-pre-test">
     <junit haltonfailure="true">
       <classpath refid="classpath.test" />
       <formatter type="brief" usefile="false" />
@@ -112,7 +112,7 @@
     <compilecommon srcdir="src" destdir="bin" classpath="classpath.base" />
   </target>
 
-  <target name="build" depends="compile" description="Build core library">
+  <target name="build" depends="methods-build, compile" description="Build core library">
     <jar basedir="bin" destfile="library/core.jar" />
   </target>
 

--- a/core/build.xml
+++ b/core/build.xml
@@ -96,7 +96,7 @@
     <delete dir="resource-test/scratch" />
   </target>
 
-  <target name="test" depends="test-compile, clean-pre-test">
+  <target name="test" depends="build, test-compile, clean-pre-test">
     <junit haltonfailure="true">
       <classpath refid="classpath.test" />
       <formatter type="brief" usefile="false" />
@@ -108,7 +108,7 @@
     </junit>
   </target>
 
-  <target name="compile" description="Compile" depends="test">
+  <target name="compile" description="Compile">
     <compilecommon srcdir="src" destdir="bin" classpath="classpath.base" />
   </target>
 

--- a/java/build.xml
+++ b/java/build.xml
@@ -124,7 +124,7 @@
     <compilecommon srcdir="src; test/processing" destdir="bin-test" classpath="classpath.test" />
   </target>
 
-  <target name="test" depends="test-compile">
+  <target name="test" depends="build, test-compile">
     <junit haltonfailure="true">
       <classpath refid="classpath.test" />
       <formatter type="brief" usefile="false" />
@@ -137,7 +137,7 @@
     </junit>
   </target>
 
-  <target name="compile" depends="test" description="Compile sources">
+  <target name="compile" description="Compile sources" depends="preproc">
     <compilecommon srcdir="src" destdir="bin" classpath="classpath.base" />
   </target>
 


### PR DESCRIPTION
Refactored ant build chain to allow building / running without execution of tests but ensure tests are run during dist. Note that tests are still runnable under the test target itself.